### PR TITLE
fix: cico deploy execute some target two times

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -2,8 +2,15 @@
 
 . cico_setup.sh
 
-cico_setup;
+load_jenkins_vars
 
-run_tests_with_coverage;
+if [ ! -f .cico-prepare ]; then
+    install_deps
+    prepare
+
+    run_tests_with_coverage;
+
+    touch .cico-prepare
+fi
 
 deploy;


### PR DESCRIPTION
Fix some target gets executed two times, one for coreos image and other for rhel image.

Check - https://ci.centos.org/view/Devtools/job/devtools-fabric8-env-build-master/2/console
Search `make docker-start`