### PR TITLE
enhancement for name,type fields

### DIFF
--- a/controller/environment.go
+++ b/controller/environment.go
@@ -44,7 +44,7 @@ func ConvertEnvironment(env *environment.Environment) *app.Environment {
 			Name:          *env.Name,
 			Type:          *env.Type,
 			NamespaceName: env.NamespaceName,
-			ClusterURL:    env.ClusterURL,
+			ClusterURL:    *env.ClusterURL,
 		},
 	}
 	return respEnv
@@ -70,7 +70,7 @@ func (c *EnvironmentController) Create(ctx *app.CreateEnvironmentContext) error 
 		return app.JSONErrorResponse(ctx, err)
 	}
 
-	err = c.checkClustersUser(ctx, *reqEnv.Attributes.ClusterURL)
+	err = c.checkClustersUser(ctx, reqEnv.Attributes.ClusterURL)
 	if err != nil {
 		return app.JSONErrorResponse(ctx, err)
 	}
@@ -82,7 +82,7 @@ func (c *EnvironmentController) Create(ctx *app.CreateEnvironmentContext) error 
 			Type:          &reqEnv.Attributes.Type,
 			SpaceID:       &spaceID,
 			NamespaceName: reqEnv.Attributes.NamespaceName,
-			ClusterURL:    reqEnv.Attributes.ClusterURL,
+			ClusterURL:    &reqEnv.Attributes.ClusterURL,
 		}
 
 		env, err = appl.Environments().Create(ctx, &newEnv)

--- a/controller/environment.go
+++ b/controller/environment.go
@@ -41,12 +41,11 @@ func ConvertEnvironment(env *environment.Environment) *app.Environment {
 		ID:   env.ID,
 		Type: APIStringTypeEnvironment,
 		Attributes: &app.EnvironmentAttributes{
-			Name:          env.Name,
-			Type:          env.Type,
+			Name:          *env.Name,
+			Type:          *env.Type,
 			NamespaceName: env.NamespaceName,
 			ClusterURL:    env.ClusterURL,
 		},
-		// TODO add links, relations
 	}
 	return respEnv
 }
@@ -79,8 +78,8 @@ func (c *EnvironmentController) Create(ctx *app.CreateEnvironmentContext) error 
 	var env *environment.Environment
 	err = application.Transactional(c.db, func(appl application.Application) error {
 		newEnv := environment.Environment{
-			Name:          reqEnv.Attributes.Name,
-			Type:          reqEnv.Attributes.Type,
+			Name:          &reqEnv.Attributes.Name,
+			Type:          &reqEnv.Attributes.Type,
 			SpaceID:       &spaceID,
 			NamespaceName: reqEnv.Attributes.NamespaceName,
 			ClusterURL:    reqEnv.Attributes.ClusterURL,

--- a/controller/environment_blackbox_test.go
+++ b/controller/environment_blackbox_test.go
@@ -131,7 +131,7 @@ func (s *EnvironmentControllerSuite) TestValidate() {
 				Attributes: &app.EnvironmentAttributes{
 					Name:          "osio-stage",
 					Type:          "stage",
-					ClusterURL:    ptr.String("cluster1.com"),
+					ClusterURL:    "cluster1.com",
 					NamespaceName: ptr.String("osio-stage"),
 				},
 			},
@@ -146,7 +146,7 @@ func (s *EnvironmentControllerSuite) TestValidate() {
 				Type: "environments",
 				Attributes: &app.EnvironmentAttributes{
 					Type:          "stage",
-					ClusterURL:    ptr.String("cluster1.com"),
+					ClusterURL:    "cluster1.com",
 					NamespaceName: ptr.String("osio-stage"),
 				},
 			},
@@ -163,7 +163,24 @@ func (s *EnvironmentControllerSuite) TestValidate() {
 				Type: "environments",
 				Attributes: &app.EnvironmentAttributes{
 					Name:          "osio-stage",
-					ClusterURL:    ptr.String("cluster1.com"),
+					ClusterURL:    "cluster1.com",
+					NamespaceName: ptr.String("osio-stage"),
+				},
+			},
+		}
+		err := env.Validate()
+		assert.Error(t, err)
+		cause := err.(*goa.ErrorResponse)
+		assert.Equal(t, 400, cause.Status)
+	})
+
+	s.T().Run("missing_cluster_url_failed", func(t *testing.T) {
+		env := app.CreateEnvironmentPayload{
+			Data: &app.Environment{
+				Type: "environments",
+				Attributes: &app.EnvironmentAttributes{
+					Name:          "osio-stage",
+					Type:          "stage",
 					NamespaceName: ptr.String("osio-stage"),
 				},
 			},
@@ -181,7 +198,7 @@ func (s *EnvironmentControllerSuite) TestValidate() {
 				Attributes: &app.EnvironmentAttributes{
 					Name:          "osio-stage",
 					Type:          "STAGE",
-					ClusterURL:    ptr.String("cluster1.com"),
+					ClusterURL:    "cluster1.com",
 					NamespaceName: ptr.String("osio-stage"),
 				},
 			},
@@ -199,7 +216,7 @@ func newCreateEnvironmentPayload(name, envType, clusterURL string) *app.CreateEn
 			Attributes: &app.EnvironmentAttributes{
 				Name:       name,
 				Type:       envType,
-				ClusterURL: &clusterURL,
+				ClusterURL: clusterURL,
 			},
 			Type: "environments",
 		},

--- a/controller/environment_blackbox_test.go
+++ b/controller/environment_blackbox_test.go
@@ -125,19 +125,29 @@ func (s *EnvironmentControllerSuite) TestShow() {
 
 func (s *EnvironmentControllerSuite) TestValidate() {
 	s.T().Run("ok", func(t *testing.T) {
-		env := app.CreateEnvironmentPayload{
-			Data: &app.Environment{
-				Type: "environments",
-				Attributes: &app.EnvironmentAttributes{
-					Name:          "osio-stage",
-					Type:          "stage",
-					ClusterURL:    "cluster1.com",
-					NamespaceName: ptr.String("osio-stage"),
-				},
-			},
+		tables := []struct {
+			name, envType string
+		}{
+			{"che-dev", "dev"},
+			{"jenkins-build", "build"},
+			{"osio-stage", "stage"},
+			{"osio-run", "run"},
 		}
-		err := env.Validate()
-		assert.NoError(t, err)
+		for _, table := range tables {
+			env := app.CreateEnvironmentPayload{
+				Data: &app.Environment{
+					Type: "environments",
+					Attributes: &app.EnvironmentAttributes{
+						Name:          table.name,
+						Type:          table.envType,
+						ClusterURL:    "cluster1.com",
+						NamespaceName: ptr.String("osio-stage"),
+					},
+				},
+			}
+			err := env.Validate()
+			assert.NoError(t, err)
+		}
 	})
 
 	s.T().Run("missing_name_failed", func(t *testing.T) {

--- a/controller/environment_blackbox_test.go
+++ b/controller/environment_blackbox_test.go
@@ -13,6 +13,7 @@ import (
 	testauth "github.com/fabric8-services/fabric8-common/test/auth"
 	testsuite "github.com/fabric8-services/fabric8-common/test/suite"
 	"github.com/fabric8-services/fabric8-env/app"
+	"github.com/fabric8-services/fabric8-env/app/test"
 	"github.com/fabric8-services/fabric8-env/configuration"
 	"github.com/fabric8-services/fabric8-env/controller"
 	"github.com/fabric8-services/fabric8-env/gormapp"

--- a/controller/environment_blackbox_test.go
+++ b/controller/environment_blackbox_test.go
@@ -126,8 +126,8 @@ func newCreateEnvironmentPayload(name, envType, clusterURL string) *app.CreateEn
 	payload := &app.CreateEnvironmentPayload{
 		Data: &app.Environment{
 			Attributes: &app.EnvironmentAttributes{
-				Name:       &name,
-				Type:       &envType,
+				Name:       name,
+				Type:       envType,
 				ClusterURL: &clusterURL,
 			},
 			Type: "environments",

--- a/design/environment.go
+++ b/design/environment.go
@@ -25,7 +25,7 @@ var envAttrs = a.Type("EnvironmentAttributes", func() {
 		a.Example("myapp-stage")
 	})
 	a.Attribute("type", d.String, "The environment type", func() {
-		a.Example("stage")
+		a.Enum("dev", "build", "stage", "run")
 	})
 	a.Attribute("namespaceName", d.String, "The namespace name", func() {
 		a.Example("myapp-stage")

--- a/design/environment.go
+++ b/design/environment.go
@@ -14,7 +14,6 @@ var env = a.Type("Environment", func() {
 		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
 	})
 	a.Attribute("attributes", envAttrs)
-	// a.Attribute("relationships", envRelationships)
 	a.Attribute("links", genericLinks)
 	a.Required("type", "attributes")
 })
@@ -33,6 +32,7 @@ var envAttrs = a.Type("EnvironmentAttributes", func() {
 	a.Attribute("cluster-url", d.String, "The cluster url", func() {
 		a.Example("https://api.starter-us-east-2a.openshift.com")
 	})
+	a.Required("name", "type")
 })
 
 // var envRelationships = a.Type("EnvironmentRelations", func() {

--- a/design/environment.go
+++ b/design/environment.go
@@ -32,7 +32,7 @@ var envAttrs = a.Type("EnvironmentAttributes", func() {
 	a.Attribute("cluster-url", d.String, "The cluster url", func() {
 		a.Example("https://api.starter-us-east-2a.openshift.com")
 	})
-	a.Required("name", "type")
+	a.Required("name", "type", "cluster-url")
 })
 
 // var envRelationships = a.Type("EnvironmentRelations", func() {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -16,6 +16,7 @@ func Steps() Scripts {
 	return [][]string{
 		{"000-bootstrap.sql"},
 		{"001-environments.sql"},
+		{"0002-alter-env-add-notnull.sql"},
 	}
 }
 

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -98,6 +98,12 @@ func checkMigration001(t *testing.T) {
 }
 
 func checkMigration002(t *testing.T) {
+	t.Run("insert_null_ok", func(t *testing.T) {
+		_, err := sqlDB.Exec(`INSERT INTO environments (id, space_id, namespace_name)
+			VALUES (uuid_generate_v4(), uuid_generate_v4(), '')`)
+		require.NoError(t, err)
+	})
+
 	err := migrationsupport.Migrate(sqlDB, databaseName, migration.Steps()[:3])
 	require.NoError(t, err)
 

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -98,13 +98,11 @@ func checkMigration001(t *testing.T) {
 }
 
 func checkMigration002(t *testing.T) {
-	t.Run("insert_null_ok", func(t *testing.T) {
-		_, err := sqlDB.Exec(`INSERT INTO environments (id, space_id, namespace_name)
+	_, err := sqlDB.Exec(`INSERT INTO environments (id, space_id, namespace_name)
 			VALUES (uuid_generate_v4(), uuid_generate_v4(), '')`)
-		require.NoError(t, err)
-	})
+	require.NoError(t, err)
 
-	err := migrationsupport.Migrate(sqlDB, databaseName, migration.Steps()[:3])
+	err = migrationsupport.Migrate(sqlDB, databaseName, migration.Steps()[:3])
 	require.NoError(t, err)
 
 	t.Run("insert_ok", func(t *testing.T) {

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -107,9 +107,15 @@ func checkMigration002(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("insert_null_failed", func(t *testing.T) {
+	t.Run("insert_null_failed1", func(t *testing.T) {
 		_, err := sqlDB.Exec(`INSERT INTO environments (id, space_id, namespace_name, cluster_url)
 			VALUES (uuid_generate_v4(), uuid_generate_v4(), '', 'cluster1.com')`)
+		require.Error(t, err)
+	})
+
+	t.Run("insert_null_failed2", func(t *testing.T) {
+		_, err := sqlDB.Exec(`INSERT INTO environments (id, name, type, space_id, namespace_name)
+			VALUES (uuid_generate_v4(), 'osio-stage', 'stage', uuid_generate_v4(), '')`)
 		require.Error(t, err)
 	})
 }

--- a/migration/sql-files/0002-alter-env-add-notnull.sql
+++ b/migration/sql-files/0002-alter-env-add-notnull.sql
@@ -1,2 +1,3 @@
 ALTER TABLE environments ALTER COLUMN name SET NOT NULL;
 ALTER TABLE environments ALTER COLUMN type SET NOT NULL;
+ALTER TABLE environments ALTER COLUMN cluster_url SET NOT NULL;

--- a/migration/sql-files/0002-alter-env-add-notnull.sql
+++ b/migration/sql-files/0002-alter-env-add-notnull.sql
@@ -1,3 +1,8 @@
+UPDATE environments SET name = 'dummy-env' WHERE name IS NULL OR name = '';
 ALTER TABLE environments ALTER COLUMN name SET NOT NULL;
+
+UPDATE environments SET type = 'stage' WHERE type IS NULL OR type = '';
 ALTER TABLE environments ALTER COLUMN type SET NOT NULL;
+
+UPDATE environments SET cluster_url = 'https://api.starter-us-east-2.openshift.com' WHERE cluster_url IS NULL OR cluster_url = '';
 ALTER TABLE environments ALTER COLUMN cluster_url SET NOT NULL;

--- a/migration/sql-files/0002-alter-env-add-notnull.sql
+++ b/migration/sql-files/0002-alter-env-add-notnull.sql
@@ -1,0 +1,2 @@
+ALTER TABLE environments ALTER COLUMN name SET NOT NULL;
+ALTER TABLE environments ALTER COLUMN type SET NOT NULL;


### PR DESCRIPTION
Fixes: https://github.com/fabric8-services/fabric8-env/issues/11
Fixes: restrict env `type` to have values dev,build,stage,run only.